### PR TITLE
remove bottom position on zoom controls

### DIFF
--- a/src/stylesheet/_zoomcontrol.scss
+++ b/src/stylesheet/_zoomcontrol.scss
@@ -2,7 +2,6 @@
   z-index: 1;
   border-radius: 4px;
   position: absolute;
-  bottom: 20px;
   left: 12px;
   background-color: #e0e0e0;
 


### PR DESCRIPTION
i added this line a few months ago when the directive was to have the zoom controls on the bottom of the screen, which was causing a container to be too long and isn't needed now so it can go away